### PR TITLE
Update framweworkVersion to match new serverless version

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -19,7 +19,7 @@ service: sls-ws
 # You can pin your service to only deploy with a specific Serverless version
 # Check out our docs for more details
 # frameworkVersion: "=X.X.X"
-frameworkVersion: ">=1.28.0 <2.0.0"
+frameworkVersion: ">=1.28.0"
 
 provider:
   name: aws


### PR DESCRIPTION
Using **<2.0.0** will throw: 
```
The Serverless version (2.18.0) does not satisfy the "frameworkVersion" (>=1.28.0 <2.0.0) in serverless.yml"
```